### PR TITLE
SQCPPGHA-13 Use unified sonarqube-scan-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,17 +13,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Install sonar-scanner
-        uses: sonarsource/sonarqube-github-c-cpp@v2
-        env:
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }} # SonarQube URL is stored in a GitHub secret
       - name: Generate compilation database
         run: |
           mkdir build
           cmake -S . -B build
-      - name: Run sonar-scanner
+      - name: Install and run Sonar Scanner
+        uses: sonarsource/sonarqube-scan-action@v4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }} # SonarQube URL is stored in a GitHub secret
-        run: sonar-scanner --define sonar.cfamily.compile-commands=build/compile_commands.json
+        with:
+          args: > 
+            --define sonar.cfamily.compile-commands=build/compile_commands.json


### PR DESCRIPTION
The [`sonarqube-scan-action@v4.2`](https://github.com/SonarSource/sonarqube-scan-action/releases/tag/v4.2.1) GHA now handles C, C++, and Objective-C projects even when Build Wrapper is needed, replacing `sonarqube-github-c-cpp`.

This PR makes the replacement.